### PR TITLE
Update info (copyright and description strings)

### DIFF
--- a/sources/Arimo-Bold.ufo/fontinfo.plist
+++ b/sources/Arimo-Bold.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaLineGap</key>
     <integer>67</integer>
     <key>openTypeNameDescription</key>
-    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial™. Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
+    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial(tm). Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
     <key>openTypeNameDesigner</key>
     <string>Steve Matteson</string>
     <key>openTypeNameDesignerURL</key>

--- a/sources/Arimo-Bold.ufo/fontinfo.plist
+++ b/sources/Arimo-Bold.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
     <key>capHeight</key>
     <integer>1409</integer>
     <key>copyright</key>
-    <string>Copyright 2010 Google Inc. All Rights Reserved.</string>
+    <string>Copyright 2020 The Arimo Project Authors (https://github.com/googlefonts/arimo)</string>
     <key>descender</key>
     <integer>-431</integer>
     <key>familyName</key>

--- a/sources/Arimo-BoldItalic.ufo/fontinfo.plist
+++ b/sources/Arimo-BoldItalic.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaLineGap</key>
     <integer>67</integer>
     <key>openTypeNameDescription</key>
-    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial™. Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
+    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial(tm). Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
     <key>openTypeNameDesigner</key>
     <string>Steve Matteson</string>
     <key>openTypeNameDesignerURL</key>

--- a/sources/Arimo-BoldItalic.ufo/fontinfo.plist
+++ b/sources/Arimo-BoldItalic.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
     <key>capHeight</key>
     <integer>1409</integer>
     <key>copyright</key>
-    <string>Copyright 2010 Google Inc. All Rights Reserved.</string>
+    <string>Copyright 2020 The Arimo Project Authors (https://github.com/googlefonts/arimo)</string>
     <key>descender</key>
     <integer>-431</integer>
     <key>familyName</key>

--- a/sources/Arimo-Italic.ufo/fontinfo.plist
+++ b/sources/Arimo-Italic.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaLineGap</key>
     <integer>67</integer>
     <key>openTypeNameDescription</key>
-    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial™. Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
+    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial(tm). Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
     <key>openTypeNameDesigner</key>
     <string>Steve Matteson</string>
     <key>openTypeNameDesignerURL</key>

--- a/sources/Arimo-Italic.ufo/fontinfo.plist
+++ b/sources/Arimo-Italic.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
     <key>capHeight</key>
     <integer>1409</integer>
     <key>copyright</key>
-    <string>Copyright 2010 Google Inc. All Rights Reserved.</string>
+    <string>Copyright 2020 The Arimo Project Authors (https://github.com/googlefonts/arimo)</string>
     <key>descender</key>
     <integer>-425</integer>
     <key>familyName</key>

--- a/sources/Arimo-Regular.ufo/fontinfo.plist
+++ b/sources/Arimo-Regular.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaLineGap</key>
     <integer>67</integer>
     <key>openTypeNameDescription</key>
-    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial™. Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
+    <string>Arimo was designed by Steve Matteson as an innovative, refreshing sans serif design that is metrically compatible with Arial(tm). Arimo offers improved on-screen readability characteristics and the pan-European WGL character set and solves the needs of developers looking for width-compatible fonts to address document portability across platforms.</string>
     <key>openTypeNameDesigner</key>
     <string>Steve Matteson</string>
     <key>openTypeNameDesignerURL</key>

--- a/sources/Arimo-Regular.ufo/fontinfo.plist
+++ b/sources/Arimo-Regular.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
     <key>capHeight</key>
     <integer>1409</integer>
     <key>copyright</key>
-    <string>Copyright 2010 Google Inc. All Rights Reserved.</string>
+    <string>Copyright 2020 The Arimo Project Authors (https://github.com/googlefonts/arimo)</string>
     <key>descender</key>
     <integer>-431</integer>
     <key>familyName</key>


### PR DESCRIPTION
Fontbakery reports issues with the copyright string and the description strings.

The copyright string is now "Copyright 2020 The Arimo Project Authors (https://github.com/googlefonts/arimo)". Hopefully that will be the correct URL.

the description string had the ™ characters, it is replaced by "(tm)".