### PR TITLE
Fix uni035C and uni0361

### DIFF
--- a/sources/Arimo-Bold.ufo/glyphs/uni035C_.glif
+++ b/sources/Arimo-Bold.ufo/glyphs/uni035C_.glif
@@ -6,20 +6,20 @@ uni035C
 </note>
   <outline>
     <contour>
-      <point x="794" y="-44" type="curve"/>
-      <point x="611" y="-44" type="line"/>
-      <point x="507" y="-200"/>
-      <point x="315" y="-278"/>
-      <point x="0" y="-278" type="curve" smooth="yes"/>
-      <point x="-332" y="-278"/>
-      <point x="-479" y="-209"/>
-      <point x="-610" y="-44" type="curve"/>
-      <point x="-793" y="-44" type="line"/>
-      <point x="-664" y="-295"/>
-      <point x="-391" y="-425"/>
-      <point x="1" y="-425" type="curve" smooth="yes"/>
-      <point x="390" y="-425"/>
-      <point x="663" y="-299"/>
+      <point x="1434" y="-44" type="curve"/>
+      <point x="1251" y="-44" type="line"/>
+      <point x="1147" y="-200"/>
+      <point x="955" y="-278"/>
+      <point x="640" y="-278" type="curve" smooth="yes"/>
+      <point x="308" y="-278"/>
+      <point x="161" y="-209"/>
+      <point x="30" y="-44" type="curve"/>
+      <point x="-153" y="-44" type="line"/>
+      <point x="-24" y="-295"/>
+      <point x="249" y="-425"/>
+      <point x="641" y="-425" type="curve" smooth="yes"/>
+      <point x="1030" y="-425"/>
+      <point x="1303" y="-299"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Arimo-Bold.ufo/glyphs/uni0361.glif
+++ b/sources/Arimo-Bold.ufo/glyphs/uni0361.glif
@@ -6,20 +6,20 @@ uni0361
 </note>
   <outline>
     <contour>
-      <point x="611" y="1220" type="curve"/>
-      <point x="794" y="1220" type="line"/>
-      <point x="663" y="1473"/>
-      <point x="390" y="1601"/>
-      <point x="1" y="1601" type="curve" smooth="yes"/>
-      <point x="-391" y="1601"/>
-      <point x="-664" y="1471"/>
-      <point x="-793" y="1220" type="curve"/>
-      <point x="-610" y="1220" type="line"/>
-      <point x="-479" y="1385"/>
-      <point x="-332" y="1454"/>
-      <point x="0" y="1454" type="curve" smooth="yes"/>
-      <point x="313" y="1454"/>
-      <point x="504" y="1377"/>
+      <point x="1211" y="1220" type="curve"/>
+      <point x="1394" y="1220" type="line"/>
+      <point x="1263" y="1473"/>
+      <point x="990" y="1601"/>
+      <point x="601" y="1601" type="curve" smooth="yes"/>
+      <point x="209" y="1601"/>
+      <point x="-64" y="1471"/>
+      <point x="-193" y="1220" type="curve"/>
+      <point x="-10" y="1220" type="line"/>
+      <point x="121" y="1385"/>
+      <point x="268" y="1454"/>
+      <point x="600" y="1454" type="curve" smooth="yes"/>
+      <point x="913" y="1454"/>
+      <point x="1104" y="1377"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Arimo-BoldItalic.ufo/glyphs/uni035C_.glif
+++ b/sources/Arimo-BoldItalic.ufo/glyphs/uni035C_.glif
@@ -6,20 +6,20 @@ uni035C
 </note>
   <outline>
     <contour>
-      <point x="793" y="-44" type="curve"/>
-      <point x="610" y="-44" type="line"/>
-      <point x="471" y="-204"/>
-      <point x="265" y="-278"/>
-      <point x="-47" y="-278" type="curve" smooth="yes"/>
-      <point x="-378" y="-278"/>
-      <point x="-511" y="-211"/>
-      <point x="-611" y="-44" type="curve"/>
-      <point x="-793" y="-44" type="line"/>
-      <point x="-713" y="-299"/>
-      <point x="-464" y="-425"/>
-      <point x="-75" y="-425" type="curve" smooth="yes"/>
-      <point x="317" y="-425"/>
-      <point x="612" y="-300"/>
+      <point x="1213" y="-44" type="curve"/>
+      <point x="1030" y="-44" type="line"/>
+      <point x="891" y="-204"/>
+      <point x="685" y="-278"/>
+      <point x="373" y="-278" type="curve" smooth="yes"/>
+      <point x="42" y="-278"/>
+      <point x="-91" y="-211"/>
+      <point x="-191" y="-44" type="curve"/>
+      <point x="-373" y="-44" type="line"/>
+      <point x="-293" y="-299"/>
+      <point x="-44" y="-425"/>
+      <point x="345" y="-425" type="curve" smooth="yes"/>
+      <point x="737" y="-425"/>
+      <point x="1032" y="-300"/>
     </contour>
   </outline>
   <lib>

--- a/sources/Arimo-BoldItalic.ufo/glyphs/uni0361.glif
+++ b/sources/Arimo-BoldItalic.ufo/glyphs/uni0361.glif
@@ -6,20 +6,20 @@ uni0361
 </note>
   <outline>
     <contour>
-      <point x="610" y="1220" type="curve"/>
-      <point x="793" y="1220" type="line"/>
-      <point x="714" y="1468"/>
-      <point x="460" y="1601"/>
-      <point x="65" y="1601" type="curve" smooth="yes"/>
-      <point x="-327" y="1601"/>
-      <point x="-612" y="1476"/>
-      <point x="-793" y="1220" type="curve"/>
-      <point x="-610" y="1220" type="line"/>
-      <point x="-449" y="1383"/>
-      <point x="-291" y="1454"/>
-      <point x="45" y="1454" type="curve" smooth="yes"/>
-      <point x="364" y="1454"/>
-      <point x="537" y="1376"/>
+      <point x="1403" y="1220" type="curve"/>
+      <point x="1586" y="1220" type="line"/>
+      <point x="1507" y="1468"/>
+      <point x="1253" y="1601"/>
+      <point x="858" y="1601" type="curve" smooth="yes"/>
+      <point x="466" y="1601"/>
+      <point x="181" y="1476"/>
+      <point x="0" y="1220" type="curve"/>
+      <point x="183" y="1220" type="line"/>
+      <point x="344" y="1383"/>
+      <point x="502" y="1454"/>
+      <point x="838" y="1454" type="curve" smooth="yes"/>
+      <point x="1157" y="1454"/>
+      <point x="1330" y="1376"/>
     </contour>
   </outline>
   <lib>

--- a/sources/Arimo-Italic.ufo/glyphs/uni035C_.glif
+++ b/sources/Arimo-Italic.ufo/glyphs/uni035C_.glif
@@ -6,20 +6,20 @@ uni035C
 </note>
   <outline>
     <contour>
-      <point x="793" y="-54" type="curve"/>
-      <point x="660" y="-54" type="line"/>
-      <point x="501" y="-227"/>
-      <point x="265" y="-302"/>
-      <point x="-50" y="-302" type="curve" smooth="yes"/>
-      <point x="-363" y="-302"/>
-      <point x="-571" y="-226"/>
-      <point x="-660" y="-54" type="curve"/>
-      <point x="-793" y="-54" type="line"/>
-      <point x="-689" y="-297"/>
-      <point x="-450" y="-425"/>
-      <point x="-73" y="-425" type="curve" smooth="yes"/>
-      <point x="286" y="-425"/>
-      <point x="582" y="-309"/>
+      <point x="1293" y="-54" type="curve"/>
+      <point x="1160" y="-54" type="line"/>
+      <point x="1001" y="-227"/>
+      <point x="765" y="-302"/>
+      <point x="450" y="-302" type="curve" smooth="yes"/>
+      <point x="137" y="-302"/>
+      <point x="-71" y="-226"/>
+      <point x="-160" y="-54" type="curve"/>
+      <point x="-293" y="-54" type="line"/>
+      <point x="-189" y="-297"/>
+      <point x="50" y="-425"/>
+      <point x="427" y="-425" type="curve" smooth="yes"/>
+      <point x="786" y="-425"/>
+      <point x="1082" y="-309"/>
     </contour>
   </outline>
   <lib>

--- a/sources/Arimo-Italic.ufo/glyphs/uni0361.glif
+++ b/sources/Arimo-Italic.ufo/glyphs/uni0361.glif
@@ -6,20 +6,20 @@ uni0361
 </note>
   <outline>
     <contour>
-      <point x="661" y="1219" type="curve"/>
-      <point x="794" y="1219" type="line"/>
-      <point x="634" y="1472"/>
-      <point x="360" y="1590"/>
-      <point x="1" y="1590" type="curve" smooth="yes"/>
-      <point x="-358" y="1590"/>
-      <point x="-633" y="1472"/>
-      <point x="-793" y="1219" type="curve"/>
-      <point x="-660" y="1219" type="line"/>
-      <point x="-535" y="1392"/>
-      <point x="-315" y="1467"/>
-      <point x="0" y="1467" type="curve" smooth="yes"/>
-      <point x="315" y="1467"/>
-      <point x="536" y="1392"/>
+      <point x="1281" y="1219" type="curve"/>
+      <point x="1414" y="1219" type="line"/>
+      <point x="1254" y="1472"/>
+      <point x="980" y="1590"/>
+      <point x="621" y="1590" type="curve" smooth="yes"/>
+      <point x="262" y="1590"/>
+      <point x="-13" y="1472"/>
+      <point x="-173" y="1219" type="curve"/>
+      <point x="-40" y="1219" type="line"/>
+      <point x="85" y="1392"/>
+      <point x="305" y="1467"/>
+      <point x="620" y="1467" type="curve" smooth="yes"/>
+      <point x="935" y="1467"/>
+      <point x="1156" y="1392"/>
     </contour>
   </outline>
   <lib>

--- a/sources/Arimo-Regular.ufo/glyphs/uni035C_.glif
+++ b/sources/Arimo-Regular.ufo/glyphs/uni035C_.glif
@@ -6,20 +6,20 @@ uni035C
 </note>
   <outline>
     <contour>
-      <point x="794" y="-54" type="curve"/>
-      <point x="661" y="-54" type="line"/>
-      <point x="536" y="-227"/>
-      <point x="315" y="-302"/>
-      <point x="0" y="-302" type="curve" smooth="yes"/>
-      <point x="-315" y="-302"/>
-      <point x="-535" y="-227"/>
-      <point x="-660" y="-54" type="curve"/>
-      <point x="-793" y="-54" type="line"/>
-      <point x="-633" y="-309"/>
-      <point x="-358" y="-425"/>
-      <point x="1" y="-425" type="curve" smooth="yes"/>
-      <point x="360" y="-425"/>
-      <point x="634" y="-309"/>
+      <point x="1394" y="-54" type="curve"/>
+      <point x="1261" y="-54" type="line"/>
+      <point x="1136" y="-227"/>
+      <point x="915" y="-302"/>
+      <point x="600" y="-302" type="curve" smooth="yes"/>
+      <point x="285" y="-302"/>
+      <point x="65" y="-227"/>
+      <point x="-60" y="-54" type="curve"/>
+      <point x="-193" y="-54" type="line"/>
+      <point x="-33" y="-309"/>
+      <point x="242" y="-425"/>
+      <point x="601" y="-425" type="curve" smooth="yes"/>
+      <point x="960" y="-425"/>
+      <point x="1234" y="-309"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Arimo-Regular.ufo/glyphs/uni0361.glif
+++ b/sources/Arimo-Regular.ufo/glyphs/uni0361.glif
@@ -6,20 +6,20 @@ uni0361
 </note>
   <outline>
     <contour>
-      <point x="661" y="1219" type="curve"/>
-      <point x="794" y="1219" type="line"/>
-      <point x="634" y="1472"/>
-      <point x="360" y="1590"/>
-      <point x="1" y="1590" type="curve" smooth="yes"/>
-      <point x="-358" y="1590"/>
-      <point x="-633" y="1472"/>
-      <point x="-793" y="1219" type="curve"/>
-      <point x="-660" y="1219" type="line"/>
-      <point x="-535" y="1392"/>
-      <point x="-315" y="1467"/>
-      <point x="0" y="1467" type="curve" smooth="yes"/>
-      <point x="315" y="1467"/>
-      <point x="536" y="1392"/>
+      <point x="1261" y="1219" type="curve"/>
+      <point x="1394" y="1219" type="line"/>
+      <point x="1234" y="1472"/>
+      <point x="960" y="1590"/>
+      <point x="601" y="1590" type="curve" smooth="yes"/>
+      <point x="242" y="1590"/>
+      <point x="-33" y="1472"/>
+      <point x="-193" y="1219" type="curve"/>
+      <point x="-60" y="1219" type="line"/>
+      <point x="65" y="1392"/>
+      <point x="285" y="1467"/>
+      <point x="600" y="1467" type="curve" smooth="yes"/>
+      <point x="915" y="1467"/>
+      <point x="1136" y="1392"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/build.sh
+++ b/sources/build.sh
@@ -12,13 +12,10 @@ rm -rf ../fonts
 
 echo "Generating Static fonts"
 mkdir -p ../fonts
-mkdir -p ../fonts/otf
 mkdir -p ../fonts/ttf
 mkdir -p ../fonts/vf
 fontmake -m Arimo.designspace -i -o ttf --output-dir ../fonts/ttf/
-fontmake -m Arimo.designspace -i -o otf --output-dir ../fonts/otf/
 fontmake -m Arimo-Italic.designspace -i -o ttf --output-dir ../fonts/ttf/
-fontmake -m Arimo-Italic.designspace -i -o otf --output-dir ../fonts/otf/
 
 echo "Generating VFs"
 fontmake -m Arimo.designspace -o variable --output-path ../fonts/vf/Arimo[wght].ttf


### PR DESCRIPTION
uni035C and uni0361 should be under or over the previous and the
following base glyphs.
This restores the outlines position from a previous version

There’s also a commit that removes building OTFs. There weren’t any OTFs in the original set.